### PR TITLE
Update common.proto attributes for Aquila

### DIFF
--- a/aquila/us/eventtemplate/v1/common.proto
+++ b/aquila/us/eventtemplate/v1/common.proto
@@ -27,4 +27,33 @@ message Common {
     display_name: "Aquila Common Template"
     description: "A common base template for Aquila event filtering. all adults, no demographic filtering"
   };
+
+  enum Sex {
+    SEX_UNSPECIFIED = 0;
+    MALE = 1;
+    FEMALE = 2;
+  }
+
+  Sex sex = 1 [(.wfa.measurement.api.v2alpha.template_field) = {
+    display_name: "Sex"
+    population_attribute: true
+    reporting_features: FILTERABLE
+    reporting_features: GROUPABLE
+    version_added: 1
+  }];
+
+  enum AgeGroup {
+    AGE_GROUP_UNSPECIFIED = 0;
+    YEARS_18_TO_34 = 1;
+    YEARS_35_TO_54 = 2;
+    YEARS_55_PLUS = 3;
+  }
+
+  AgeGroup age_group = 2 [(.wfa.measurement.api.v2alpha.template_field) = {
+    display_name: "Age Group"
+    population_attribute: true
+    reporting_features: FILTERABLE
+    reporting_features: GROUPABLE
+    version_added: 1
+  }];
 }

--- a/aquila/us/eventtemplate/v1/common.proto
+++ b/aquila/us/eventtemplate/v1/common.proto
@@ -39,7 +39,7 @@ message Common {
     population_attribute: true
     reporting_features: FILTERABLE
     reporting_features: GROUPABLE
-    version_added: 1
+    version_added: 2
   }];
 
   enum AgeGroup {
@@ -54,6 +54,6 @@ message Common {
     population_attribute: true
     reporting_features: FILTERABLE
     reporting_features: GROUPABLE
-    version_added: 1
+    version_added: 2
   }];
 }

--- a/aquila/us/eventtemplate/v1/event.proto
+++ b/aquila/us/eventtemplate/v1/event.proto
@@ -27,7 +27,7 @@ option java_multiple_files = true;
 
 message Event {
   option (.wfa.measurement.api.v2alpha.event) = {
-    current_version: 1
+    current_version: 2
   };
 
   Common common = 1;


### PR DESCRIPTION
This pull request adds demographic attributes to the `Common` message in `aquila/us/eventtemplate/v1/common.proto` to support more flexible event filtering and reporting. Specifically, it introduces `sex` and `age_group` fields, each with their own enums, and annotates them for use as population attributes and for reporting features.

**Demographic attribute additions:**

* Added a `Sex` enum (`SEX_UNSPECIFIED`, `MALE`, `FEMALE`) and a `sex` field to the `Common` message, annotated as a population attribute and marked as filterable and groupable for reporting.
* Added an `AgeGroup` enum (`AGE_GROUP_UNSPECIFIED`, `YEARS_18_TO_34`, `YEARS_35_TO_54`, `YEARS_55_PLUS`) and an `age_group` field to the `Common` message, also annotated as a population attribute and marked as filterable and groupable for reporting.